### PR TITLE
1.2.2

### DIFF
--- a/example/cli-scripts/sync-models.php
+++ b/example/cli-scripts/sync-models.php
@@ -14,12 +14,3 @@
 
 	// Sync the models to the current local MySQL database
 	$abyss->syncModels();
-
-	// For this example, test User creation
-	$newUser = $abyss->instanceFromModel(User::getModel()); // Fetch blank User class
-	$newUser->save(); // This will insert it into the DB
-	var_dump($newUser->id); // Will be the new user ID
-
-	// Can modify and save it again
-	$newUser->name = "nox" . rand(1,100);
-	$newUser->save();

--- a/example/controllers/HomeController.php
+++ b/example/controllers/HomeController.php
@@ -5,19 +5,20 @@
 
 	require_once __DIR__ . "/../attributes/NeverUsable.php";
 
+	use Nox\RenderEngine\Renderer;
 	use Nox\Router\Attributes\Route;
 
 	class HomeController extends \Nox\Router\BaseController{
 
 		#[Route("GET", "/")]
 		public function homeView(): string{
-			return \Nox\RenderEngine\Renderer::renderView("home.html");
+			return Renderer::renderView("home.html");
 		}
 
 		#[Route("GET", "/always-404")]
 		#[NeverUsable()]
 		public function always404View(): string{
 			return "uh-oh";
-			//return \Nox\RenderEngine\Renderer::renderView("home.html");
+			// return Renderer::renderView("home.html");
 		}
 	}

--- a/example/layouts/base.php
+++ b/example/layouts/base.php
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
-<head>
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<?= $htmlHead ?>
-</head>
-<body>
-	<?= $htmlBody ?>
-</body>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<?= $htmlHead ?>
+	</head>
+	<body>
+		<?= $htmlBody ?>
+	</body>
 </html>

--- a/example/models/UsersModel.php
+++ b/example/models/UsersModel.php
@@ -34,6 +34,7 @@
 					defaultValue: 0,
 					autoIncrement: true,
 					isPrimary: true,
+					isNull:false,
 				),
 				new ColumnDefinition(
 					name:"name",

--- a/example/nox-env.example.php
+++ b/example/nox-env.example.php
@@ -1,0 +1,9 @@
+<?php
+	class NoxEnv{
+		const DEV_ENV = "development";
+		const MYSQL_HOST = "localhost";
+		const MYSQL_PORT = "3306";
+		const MYSQL_USERNAME = "root";
+		const MYSQL_PASSWORD = "";
+		const MYSQL_DB_NAME = "test";
+	}


### PR DESCRIPTION
- Update example with brief coding standards fix
- Fix missing `isNull` in primary key definition for MySQL vs MariaDB problem
- Update sync-models.php script to only sync MySQL models and not also run a unit test example