### PR TITLE
1.4.0

### DIFF
--- a/example/controllers/ExampleAPIController.php
+++ b/example/controllers/ExampleAPIController.php
@@ -3,14 +3,12 @@
 	// No need to require the autoload in the Controller.
 	// The controller has the scope of the request.php file
 
-	require_once __DIR__ . "/../attributes/NeverUsable.php";
-
-	use Nox\RenderEngine\Renderer;
 	use Nox\Router\Attributes\Route;
 	use Nox\Router\Attributes\RouteBase;
+	use Nox\Router\BaseController;
 
 	#[RouteBase("/\/api\/(?<version>v\d)/", true)]
-	class ExampleAPIController extends \Nox\Router\BaseController{
+	class ExampleAPIController extends BaseController{
 
 		#[Route("GET", "/")]
 		public function apiHomeView(): string{

--- a/example/nox-request.php
+++ b/example/nox-request.php
@@ -20,11 +20,7 @@
 	Abyss::loadConfig(__DIR__);
 
 	// Load the request handler
-	$requestHandler = new \Nox\Router\RequestHandler(
-		$router,
-		$requestPath,
-		$_SERVER['REQUEST_METHOD']
-	);
+	$requestHandler = new \Nox\Router\RequestHandler($router);
 
 	// Process the request
 	$requestHandler->processRequest();

--- a/example/nox-request.php
+++ b/example/nox-request.php
@@ -21,6 +21,7 @@
 
 	// Load the request handler
 	$requestHandler = new \Nox\Router\RequestHandler($router);
+	\Nox\Router\BaseController::$requestHandler = $requestHandler;
 
 	// Process the request
 	$requestHandler->processRequest();

--- a/src/Router/BaseController.php
+++ b/src/Router/BaseController.php
@@ -2,5 +2,5 @@
 	namespace Nox\Router;
 
 	class BaseController{
-
+		static ?RequestHandler $requestHandler = null;
 	}

--- a/src/Router/DynamicRoute.php
+++ b/src/Router/DynamicRoute.php
@@ -1,0 +1,21 @@
+<?php
+	namespace Nox\Router;
+
+	class DynamicRoute{
+		public function __construct(
+			public string $requestMethod,
+			public string $requestPath,
+			public bool $isRegex,
+			public \Closure $onRender,
+
+			/**
+			 * This function is called before onRender. It must return a DynamicRouteResponse
+			 * that defines whether or not this route can pass.
+			 */
+			public ?\Closure $onRouteCheck = null,
+		){
+			// Force path and method to be lowercase
+			$this->requestPath = strtolower($this->requestPath);
+			$this->requestMethod = strtolower($this->requestMethod);
+		}
+	}

--- a/src/Router/DynamicRouteResponse.php
+++ b/src/Router/DynamicRouteResponse.php
@@ -1,0 +1,12 @@
+<?php
+	namespace Nox\Router;
+
+	class DynamicRouteResponse{
+		public function __construct(
+			public bool $isRouteUsable,
+			public ?int $responseCode = null,
+			public ?string $newRequestPath = null
+		){
+
+		}
+	}

--- a/src/Router/Exceptions/RouteMethodMustHaveANonNullReturn.php
+++ b/src/Router/Exceptions/RouteMethodMustHaveANonNullReturn.php
@@ -1,0 +1,5 @@
+<?php
+
+	namespace Nox\Router\Exceptions;
+
+	class RouteMethodMustHaveANonNullReturn extends \Exception{}

--- a/src/Router/RequestHandler.php
+++ b/src/Router/RequestHandler.php
@@ -17,14 +17,8 @@
 
 		public function __construct(
 			public Router $router,
-			public string $requestPath,
-			public string $requestType,
 			public int $recursionDepth = 0,
-		){
-			if (substr($requestPath, 0, 1) !== "/") {
-				$this->requestPath = sprintf("/%s", $requestPath);
-			}
-		}
+		){}
 
 		/**
 		 * Process an HTTP request

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -8,6 +8,7 @@
 	use Nox\Router\Attributes\RouteBase;
 	use Nox\Router\Exceptions\InvalidJSON;
 	use Nox\Router\Exceptions\RouteBaseNoMatch;
+	use Nox\Router\Exceptions\RouteMethodMustHaveANonNullReturn;
 	use Nox\Router\Interfaces\RouteAttribute;
 
 	require_once __DIR__ . "/Attributes/Route.php";

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -145,9 +145,23 @@
 			string $innerDirectory = ""
 		): void{
 			if ($innerDirectory === ""){
-				$fileNames = array_diff(scandir($this->controllersFolder), ['.','..']);
+				$fileNames = array_diff(
+					scandir(
+						$this->controllersFolder
+					),
+					['.','..'],
+				);
 			}else{
-				$fileNames = array_diff(scandir(sprintf("%s/%s", $this->controllersFolder, $innerDirectory)), ['.','..']);
+				$fileNames = array_diff(
+					scandir(
+						sprintf(
+							"%s/%s",
+							$this->controllersFolder,
+							$innerDirectory
+						)
+					),
+					['.','..'],
+				);
 			}
 
 			foreach ($fileNames as $controllerFileName){
@@ -187,6 +201,7 @@
 		/**
 		 * Checks if a class can be routed.
 		 * Currently only checks for the presence and validity RouteBase attribute.
+		 * @throws RouteBaseNoMatch
 		 */
 		public function getBaselessRouteForClass(\ReflectionClass $classReflection): string{
 			$attributes = $classReflection->getAttributes();

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -167,9 +167,18 @@
 
 			foreach ($fileNames as $controllerFileName){
 				if ($innerDirectory === ""){
-					$controllerPath = sprintf("%s/%s", $this->controllersFolder, $controllerFileName);
+					$controllerPath = sprintf(
+						"%s/%s",
+						$this->controllersFolder,
+						$controllerFileName,
+					);
 				}else{
-					$controllerPath = sprintf("%s/%s/%s", $this->controllersFolder, $innerDirectory, $controllerFileName);
+					$controllerPath = sprintf(
+						"%s/%s/%s",
+						$this->controllersFolder,
+						$innerDirectory,
+						$controllerFileName,
+					);
 				}
 
 				if (is_dir($controllerPath)){

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -387,6 +387,28 @@
 				}
 			}
 
+			// Now check all the dynamic route methods
+			/** @var DynamicRoute $dynamicRoute */
+			foreach($this->dynamicRoutes as $dynamicRoute){
+				// Check the onRenderCheck callback
+				if ($dynamicRoute->onRouteCheck !== null) {
+					/** @var DynamicRouteResponse $dynamicRouteResponse */
+					$dynamicRouteResponse = $dynamicRoute->onRouteCheck->call(new BaseController);
+					if (!$dynamicRouteResponse->isRouteUsable) {
+						// Skip this dynamic route
+						continue;
+					}
+				}
+
+				if ($dynamicRoute->isRegex){
+					if ($includeRegexRoutes){
+						$availableURIs[] = $dynamicRoute->requestPath;
+					}
+				}else{
+					$availableURIs[] = $dynamicRoute->requestPath;
+				}
+			}
+
 			return $availableURIs;
 		}
 

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -283,11 +283,6 @@
 				// below will have the base chopped off
 				$requestPath = $methodData[2];
 
-				if (!str_starts_with($requestPath, "/")){
-					$requestPath = "/" . $requestPath;
-				}
-
-
 				// The router will first find all methods
 				// that have a matching route.
 				// Then, later, it will verify any additional attributes

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -383,7 +383,21 @@
 						// If the number of valid RouteAttribute attributes equals the number
 						// found on this route method, then invoke this route controller
 						if ($passedAttributes === $neededToRoute){
-							return $routableMethod->invoke($classInstance);
+							$routeReturn = $routableMethod->invoke($classInstance);
+							if ($routeReturn === null){
+								// A route must have a return type, otherwise
+								// returning null here would make the request handler
+								// think this is a 404
+								throw new RouteMethodMustHaveANonNullReturn(
+									sprintf(
+										"A route was matched and the method %s::%s was called, but null was returned. All route methods must have a non-null return type.",
+										$classInstance::class,
+										$routableMethod->name,
+									)
+								);
+							}else {
+								return $routeReturn;
+							}
 						}
 					}
 				}

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -357,12 +357,7 @@
 											$newRouter->noxConfig = $this->noxConfig;
 											$newRouter->controllersFolder = $this->controllersFolder;
 											$newRouter->loadMVCControllers();
-											$newRequestHandler = new RequestHandler(
-												$newRouter,
-												$attributeResponse->newRequestPath,
-												$currentRequestHandler->requestType,
-												$currentRequestHandler->recursionDepth,
-											);
+											$newRequestHandler = new RequestHandler($newRouter);
 											$newRequestHandler->processRequest();
 											exit();
 										}else{

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -319,6 +319,8 @@
 					// The first one to pass all should be invoked as the correct
 					// route.
 					$acceptedRoutes = [];
+
+					/** @var \ReflectionMethod $routableMethod */
 					foreach ($routeMethodsToAttempt as $routableMethod){
 						$attributes = $routableMethod->getAttributes();
 

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -31,6 +31,10 @@
 			public string $requestPath,
 			public string $requestMethod,
 		){
+			// Force the requestPath and requestMethod to be lowercase
+			$this->requestPath = strtolower($this->requestPath);
+			$this->requestMethod = strtolower($this->requestMethod);
+
 			if (!str_starts_with($this->requestPath, "/")){
 				$this->requestPath = "/" . $this->requestPath;
 			}

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -239,6 +239,8 @@
 
 		/**
 		 * Routes a request to a controller
+		 * @throws RouteMethodMustHaveANonNullReturn
+		 * @throws \ReflectionException
 		 */
 		public function route(
 			RequestHandler $currentRequestHandler,

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -236,9 +236,9 @@
 		 * Routes a request to a controller
 		 */
 		public function route(
-			string $requestMethod,
 			RequestHandler $currentRequestHandler,
 		): mixed{
+			$requestMethod = $this->requestMethod;
 
 			// Go through all the methods collected from the controller classes
 			foreach ($this->routableMethods as $methodData){

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -397,7 +397,7 @@
 										$routableMethod->name,
 									)
 								);
-							}else {
+							}else{
 								return $routeReturn;
 							}
 						}

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -140,6 +140,7 @@
 		/**
 		 * Loads the MVC controller classes
 		 * from the controllers folder
+		 * @throws \ReflectionException
 		 */
 		public function loadMVCControllers(
 			string $innerDirectory = ""

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -565,31 +565,34 @@
 				if ($dynamicRoute->requestMethod === $this->requestMethod) {
 					if ($dynamicRoute->onRouteCheck !== null) {
 						/** @var DynamicRouteResponse $dynamicRouteResponse */
-						$dynamicRouteResponse = $dynamicRoute->onRouteCheck->call();
-						if ($dynamicRouteResponse->isRouteUsable) {
+						$dynamicRouteResponse = $dynamicRoute->onRouteCheck->call(new BaseController);
+						if ($dynamicRouteResponse->isRouteUsable === true) {
 							// All good
 						} else {
 							if ($dynamicRouteResponse->responseCode !== null || $dynamicRouteResponse->newRequestPath !== null) {
 								if ($dynamicRouteResponse->responseCode !== null) {
 									http_response_code($dynamicRouteResponse->responseCode);
-									if ($dynamicRouteResponse->newRequestPath !== null) {
-										// There is a new request path
-										// Instantiate a new request handler now and handle it
-										// A new router must also be created
-										$newRouter = new Router(
-											$dynamicRouteResponse->newRequestPath,
-											$this->requestMethod,
-										);
-										$newRouter->staticFileHandler = $this->staticFileHandler;
-										$newRouter->viewSettings = $this->viewSettings;
-										$newRouter->noxConfig = $this->noxConfig;
-										$newRouter->controllersFolder = $this->controllersFolder;
-										$newRouter->loadMVCControllers();
-										$newRequestHandler = new RequestHandler($newRouter);
-										$newRequestHandler->processRequest();
-										exit();
-									}
 								}
+								if ($dynamicRouteResponse->newRequestPath !== null) {
+									// There is a new request path
+									// Instantiate a new request handler now and handle it
+									// A new router must also be created
+									$newRouter = new Router(
+										$dynamicRouteResponse->newRequestPath,
+										$this->requestMethod,
+									);
+									$newRouter->staticFileHandler = $this->staticFileHandler;
+									$newRouter->viewSettings = $this->viewSettings;
+									$newRouter->noxConfig = $this->noxConfig;
+									$newRouter->controllersFolder = $this->controllersFolder;
+									$newRouter->loadMVCControllers();
+									$newRequestHandler = new RequestHandler($newRouter);
+									$newRequestHandler->processRequest();
+									exit();
+								}
+							}else{
+								// Just skip this route
+								continue;
 							}
 						}
 					}

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -373,7 +373,7 @@
 									}else{
 										// Break this current loop and move on to the next.
 										// The route isn't usable, but the attribute response
-										// did not change the request code or path
+										// did not change the HTTP response code or rewrite the route path
 										break 1;
 									}
 								}


### PR DESCRIPTION
Closes #10 
Closes #11 

- The Router is now the only location where the internal routing system stores and reads the requestMethod and requestPath. Removed from RequestHandler properties.
- Updates nox-request.php skeleton to reflect that certain parameters are no longer available in the RequestHandler constructor.
- Stops allowing route methods from returning null. This causes the BequestHandler to believe no route was found. Now throws an exception.
- Add new DynamicRoute to allow custom logic for routing (such as a CMS which has a database of routable pages).
- Add new method to fetch all routable URIs. Mainly used for dynamic sitemap generation.