### PR TITLE
Add fetch and query to ModelClass

### DIFF
--- a/src/ORM/Abyss.php
+++ b/src/ORM/Abyss.php
@@ -2,12 +2,14 @@
 
 	namespace Nox\ORM;
 
+	use Nox\ORM\Exceptions\NoPrimaryKey;
 	use Nox\ORM\Exceptions\ObjectMissingModelProperty;
 	use Nox\ORM\Interfaces\ModelInstance;
 	use Nox\ORM\Interfaces\MySQLModelInterface;
 	use Nox\ORM\MySQLDataTypes\DataType;
 
 	require_once __DIR__ . "/Exceptions/ObjectMissingModelProperty.php";
+	require_once __DIR__ . "/Exceptions/NoPrimaryKey.php";
 
 	class Abyss{
 
@@ -374,7 +376,7 @@
 				$statement->bind_param($boundParameterFlag, $classInstance->{$primaryPropertyName});
 				$statement->execute();
 			}else{
-				throw new \Exception("No primary key set for table " . $model->getName());
+				throw new NoPrimaryKey("No primary key set for table " . $model->getName());
 			}
 		}
 

--- a/src/ORM/Exceptions/NoPrimaryKey.php
+++ b/src/ORM/Exceptions/NoPrimaryKey.php
@@ -1,0 +1,5 @@
+<?php
+
+	namespace Nox\ORM\Exceptions;
+
+	class NoPrimaryKey extends \Exception{}

--- a/src/ORM/ModelClass.php
+++ b/src/ORM/ModelClass.php
@@ -2,7 +2,7 @@
 
 	namespace Nox\ORM;
 
-	use Exception;
+	use Nox\ORM\Exceptions\NoPrimaryKey;
 	use \Nox\ORM\Interfaces\ModelInstance;
 	use Nox\ORM\Interfaces\MySQLModelInterface;
 
@@ -34,7 +34,7 @@
 
 		/**
 		 * Deletes a singular class model instance
-		 * @throws Exception
+		 * @throws NoPrimaryKey
 		 */
 		public function delete():void{
 			$abyss = new Abyss;

--- a/src/ORM/ModelClass.php
+++ b/src/ORM/ModelClass.php
@@ -9,6 +9,37 @@
 	class ModelClass implements ModelInstance{
 
 		/**
+		 * Fetches a ModelClass by the primary key
+		 */
+		public static function fetch(mixed $primaryKey): ModelClass|null{
+			$abyss = new Abyss();
+			$thisModel = static::getModel();
+			$primaryKeyClassPropertyName = $abyss->getPrimaryKey($thisModel);
+			return $abyss->fetchInstanceByModelPrimaryKey(
+				model: $thisModel,
+				keyValue: $primaryKey,
+			);
+		}
+
+		/**
+		 * Queries all instances of ModelClass that meet the provided query criteria from
+		 * the provided parameters. Will always return an array, but the array may be empty.
+		 */
+		public static function query(
+			ColumnQuery $columnQuery = null,
+			ResultOrder $resultOrder = null,
+			Pager $pager = null,
+		): array {
+			$abyss = new Abyss();
+			return $abyss->fetchInstances(
+				model: static::getModel(),
+				columnQuery: $columnQuery,
+				resultOrder: $resultOrder,
+				pager: $pager,
+			);
+		}
+
+		/**
 		 * @throws Exceptions\ObjectMissingModelProperty
 		 */
 		public function __construct(ModelInstance $modelClass){


### PR DESCRIPTION
All ModelClass extensions can now call static methods to fetch and query their types.

```php
$users = User::query(); // Queries all users as an array
$user = User::fetch(1); // Fetch a user with primary key value 1
```