### PR TITLE
1.5.0

### DIFF
--- a/src/Http/Attributes/ChosenRouteAttribute.php
+++ b/src/Http/Attributes/ChosenRouteAttribute.php
@@ -1,0 +1,12 @@
+<?php
+	namespace Nox\Http\Attributes;
+
+	/**
+	 * An extendable classes that lets the router know this attribute should only be instantiated
+	 * if a Route has been chosen as the correct route to serve a request - after all other checks have passed.
+	 * @since 1.5.0
+	 */
+	#[\Attribute(\Attribute::TARGET_METHOD)]
+	class ChosenRouteAttribute{
+
+	}

--- a/src/Http/Attributes/ProcessRequestBody.php
+++ b/src/Http/Attributes/ProcessRequestBody.php
@@ -1,0 +1,26 @@
+<?php
+	namespace Nox\Http\Attributes;
+
+	require_once __DIR__ . "/../Request.php";
+	require_once __DIR__ . "/../../Router/BaseController.php";
+	require_once __DIR__ . "/ChosenRouteAttribute.php";
+
+	use Nox\Http\Request;
+	use Nox\Router\BaseController;
+
+	/**
+	 * @since 1.5.0
+	 */
+	#[\Attribute(\Attribute::TARGET_METHOD)]
+	class ProcessRequestBody extends ChosenRouteAttribute {
+		public function __construct(){
+			// First, try and just reference the POST data that PHP processes internally.
+			// Because php://input is blank if this is a POST request that PHP already handled.
+			if (strtolower($_SERVER['REQUEST_METHOD']) === "post" && !empty($_POST)){
+				BaseController::$requestPayload = &$_POST;
+			}else {
+				$request = new Request();
+				BaseController::$requestPayload = $request->processRequestBody();
+			}
+		}
+	}

--- a/src/Http/Attributes/UseJSON.php
+++ b/src/Http/Attributes/UseJSON.php
@@ -1,0 +1,18 @@
+<?php
+	namespace Nox\Http\Attributes;
+
+	use Nox\Router\BaseController;
+
+	require_once __DIR__ . "/ChosenRouteAttribute.php";
+	require_once __DIR__ . "/../../Router/BaseController.php";
+
+	/**
+	 * @since 1.5.0
+	 */
+	#[\Attribute(\Attribute::TARGET_METHOD)]
+	class UseJSON extends ChosenRouteAttribute {
+		public function __construct(){
+			header("content-type: application/json; charset=UTF-8");
+			BaseController::$outputArraysAsJSON = true;
+		}
+	}

--- a/src/Http/Interfaces/ArrayLike.php
+++ b/src/Http/Interfaces/ArrayLike.php
@@ -1,0 +1,6 @@
+<?php
+	namespace Nox\Http\Interfaces;
+
+	interface ArrayLike{
+		public function toArray(): array;
+	}

--- a/src/Http/JSON/JSONError.php
+++ b/src/Http/JSON/JSONError.php
@@ -1,0 +1,23 @@
+<?php
+	namespace Nox\Http\JSON;
+
+	require_once __DIR__ . "/../Interfaces/ArrayLike.php";
+
+	use Nox\Http\Interfaces\ArrayLike;
+
+	class JSONError extends JSONResult implements ArrayLike{
+
+		private array $data = [
+			"status"=>-1,
+		];
+
+		public function __construct(string $errorMessage, array $additionalData = []){
+			$this->data['error'] = $errorMessage;
+			$this->data = array_merge($this->data, $additionalData);
+		}
+
+		public function toArray(): array
+		{
+			return $this->data;
+		}
+	}

--- a/src/Http/JSON/JSONResult.php
+++ b/src/Http/JSON/JSONResult.php
@@ -1,0 +1,8 @@
+<?php
+	namespace Nox\Http\JSON;
+
+	require_once __DIR__ . "/../Interfaces/ArrayLike.php";
+
+	use Nox\Http\Interfaces\ArrayLike;
+
+	abstract class JSONResult implements ArrayLike{}

--- a/src/Http/JSON/JSONSuccess.php
+++ b/src/Http/JSON/JSONSuccess.php
@@ -1,0 +1,22 @@
+<?php
+	namespace Nox\Http\JSON;
+
+	require_once __DIR__ . "/../Interfaces/ArrayLike.php";
+
+	use Nox\Http\Interfaces\ArrayLike;
+
+	class JSONSuccess extends JSONResult implements ArrayLike{
+
+		private array $data = [
+			"status"=>1,
+		];
+
+		public function __construct(array $additionalData = []){
+			$this->data = array_merge($this->data, $additionalData);
+		}
+
+		public function toArray(): array
+		{
+			return $this->data;
+		}
+	}

--- a/src/Router/Attributes/Controller.php
+++ b/src/Router/Attributes/Controller.php
@@ -1,0 +1,8 @@
+<?php
+
+	namespace Nox\Router\Attributes;
+
+	#[\Attribute(\Attribute::TARGET_CLASS)]
+	class Controller{
+		public function __construct(){}
+	}

--- a/src/Router/BaseController.php
+++ b/src/Router/BaseController.php
@@ -3,4 +3,9 @@
 
 	class BaseController{
 		static ?RequestHandler $requestHandler = null;
+
+		/**
+		 * @var array Parameters from the route that are captured using regular expressions
+		 */
+		public static array $requestParameters = [];
 	}

--- a/src/Router/BaseController.php
+++ b/src/Router/BaseController.php
@@ -8,4 +8,9 @@
 		 * @var array Parameters from the route that are captured using regular expressions
 		 */
 		public static array $requestParameters = [];
+
+		/**
+		 * @var bool Flag to output controller method return array values as JSON strings
+		 */
+		public static bool $outputArraysAsJSON = false;
 	}

--- a/src/Router/BaseController.php
+++ b/src/Router/BaseController.php
@@ -2,7 +2,7 @@
 	namespace Nox\Router;
 
 	class BaseController{
-		static ?RequestHandler $requestHandler = null;
+		public static ?RequestHandler $requestHandler = null;
 
 		/**
 		 * @var array Parameters from the route that are captured using regular expressions
@@ -13,4 +13,10 @@
 		 * @var bool Flag to output controller method return array values as JSON strings
 		 */
 		public static bool $outputArraysAsJSON = false;
+
+		/**
+		 * @var array|null The parsed request body payload as an array - if it was processed. Helps
+		 * in instances of non-PHP support rest request methods such as DELETE/PUT/PATCH.
+		 */
+		public static ?array $requestPayload = null;
 	}

--- a/src/Router/Exceptions/StrictControllerMissingExtension.php
+++ b/src/Router/Exceptions/StrictControllerMissingExtension.php
@@ -1,0 +1,5 @@
+<?php
+
+	namespace Nox\Router\Exceptions;
+
+	class StrictControllerMissingExtension extends \Exception{}

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -602,6 +602,20 @@
 									)
 								);
 							}else{
+
+								// Check if the routeReturn is an object that implements the ArrayLike interface
+								// If so, convert it to an array
+								if (is_object($routeReturn)){
+									if ($routeReturn instanceof ArrayLike){
+										$routeReturn = $routeReturn->toArray();
+									}
+								}
+
+								// Check if arrays should be output as JSON
+								if (is_array($routeReturn) && BaseController::$outputArraysAsJSON){
+									return json_encode($routeReturn);
+								}
+
 								return $routeReturn;
 							}
 						}

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -589,6 +589,23 @@
 						// If the number of valid RouteAttribute attributes equals the number
 						// found on this route method, then invoke this route controller
 						if ($passedAttributes === $neededToRoute){
+
+							/**
+							 * Check any Attributes that extend the internal Nox attribute ChosenRouteAttribute
+							 * which are attributes that should only run for chosen routes - as they can affect the
+							 * response.
+							 * @since 1.5.0
+							 */
+							foreach($attributes as $attribute){
+								$attributeClass = new \ReflectionClass($attribute->getName());
+								$attributeParentClassName = $attributeClass->getParentClass();
+								if ($attributeParentClassName instanceof \ReflectionClass) {
+									if ($attributeParentClassName->getName() === ChosenRouteAttribute::class) {
+										$attribute->newInstance();
+									}
+								}
+							}
+
 							$routeReturn = $routableMethod->invoke($classInstance);
 							if ($routeReturn === null){
 								// A route must have a return type, otherwise

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -486,7 +486,7 @@
 						$attrName = $attribute->getName();
 
 						// Check if this attribute name is "Route"
-						if ($attrName === "Nox\\Router\\Attributes\\Route"){
+						if ($attrName === Route::class){
 							$routeAttribute = $attribute->newInstance();
 
 							// Check if the first argument (request method arg)

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -507,6 +507,10 @@
 										foreach ($matches as $name=>$match){
 											if (is_string($name)){
 												if (isset($match[0])){
+													// Define the matched parameter into the BaseController::$requestParameters
+													BaseController::$requestParameters[$name] = $match[0];
+
+													// TODO Deprecate/Remove this
 													$_GET[$name] = $match[0];
 												}
 											}
@@ -668,6 +672,10 @@
 							foreach ($matches as $name=>$match){
 								if (is_string($name)){
 									if (isset($match[0])){
+										// Define the matched parameter into the BaseController::$requestParameters
+										BaseController::$requestParameters[$name] = $match[0];
+
+										// TODO Deprecate/Remove this
 										$_GET[$name] = $match[0];
 									}
 								}

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -1,6 +1,8 @@
 <?php
 	namespace Nox\Router;
 
+	use Nox\Http\Attributes\ChosenRouteAttribute;
+	use Nox\Http\Interfaces\ArrayLike;
 	use Nox\Http\Request;
 	use Nox\ORM\Abyss;
 	use Nox\RenderEngine\Renderer;
@@ -540,9 +542,11 @@
 						$passedAttributes = 0;
 
 						foreach ($attributes as $attribute){
-							/** @var RouteAttribute $attrInstance */
-							$attrInstance = $attribute->newInstance();
-							if ($attrInstance instanceof RouteAttribute){
+							$attributeClass = new \ReflectionClass($attribute->getName());
+							$attributeParentClassName = $attributeClass->getParentClass();
+							if ($attributeParentClassName instanceof \ReflectionClass && $attributeParentClassName->getName() === RouteAttribute::class){
+								/** @var RouteAttribute $attrInstance */
+								$attrInstance = $attribute->newInstance();
 								++$neededToRoute;
 
 								$attributeResponse = $attrInstance->getAttributeResponse();


### PR DESCRIPTION
- Add new native JSONResult implementations: JSONSuccess and JSONError
- Allow the router to handle a new ArrayLike interface by converting them to arrays
- With the new UseJSON native Nox attribute, the router will convert array results to JSON strings for output and set the proper headers with UTF-8 encoding
- Introduce a new ProcessRequestBody attribute to process any raw request bodies such as PATCH/PUT/DELETE into the BaseController::$requestPayload array
- Push URL parameters to BaseController::$requestParameters to deprecate the use of the $_GET superglobal holding them
- Update how the Router finds Controllers to allow for namespaced controller classes to be supported
- Introduce a new Controller attribute that targets classes to explicitly define a class as a controller to possibly support future compiling of any class into a controller.