### PR TITLE
1.5.3

### DIFF
--- a/src/ORM/Abyss.php
+++ b/src/ORM/Abyss.php
@@ -218,12 +218,25 @@
 					$whereClause .= sprintf(" %s ", $clause['clauseJoinWord']);
 				} elseif ($clauseType === "where") {
 					$columnName = $clause['column'];
+					$columnNameFormatted = "";
+
+					// Determine if the columnName should have backticks
+					if (str_starts_with(strtolower($columnName), "coalesce(")){
+						$columnNameFormatted = sprintf("%s", $columnName);
+						$preparedBindDataTypes .= "s"; // Loop below won't find this column name
+					}elseif (str_starts_with(strtolower($columnName), "concat(")){
+						$columnNameFormatted = sprintf("%s", $columnName);
+						$preparedBindDataTypes .= "s"; // Loop below won't find this column name
+					}else{
+						$columnNameFormatted = sprintf("`%s`", $columnName);
+					}
+
 					$isRaw = $clause['raw'];
 					$condition = trim(strtolower($clause['condition']));
 					$value = $clause['value'];
 
 					if ($isRaw){
-						$whereClause .= sprintf("`%s` %s %s", $columnName, $condition, $value);
+						$whereClause .= sprintf("`%s` %s %s", $columnNameFormatted, $condition, $value);
 					}else {
 						if (
 							$condition !== "is" &&
@@ -242,10 +255,10 @@
 							}
 
 							$boundValues[] = $value;
-							$whereClause .= sprintf("`%s` %s ?", $columnName, $condition);
+							$whereClause .= sprintf("%s %s ?", $columnNameFormatted, $condition);
 						} else {
 							// IS, IS NOT, IN, and NOT IN
-							$whereClause .= sprintf("`%s` %s %s", $columnName, $condition, $value);
+							$whereClause .= sprintf("%s %s %s", $columnNameFormatted, $condition, $value);
 						}
 					}
 				}

--- a/src/ORM/Exceptions/NoColumnWithPropertyName.php
+++ b/src/ORM/Exceptions/NoColumnWithPropertyName.php
@@ -1,0 +1,5 @@
+<?php
+
+	namespace Nox\ORM\Exceptions;
+
+	class NoColumnWithPropertyName extends \Exception{}

--- a/src/ORM/ModelClass.php
+++ b/src/ORM/ModelClass.php
@@ -9,6 +9,19 @@
 	class ModelClass implements ModelInstance{
 
 		/**
+		 * @param string $propertyName
+		 * @return string
+		 * @throws Exceptions\NoColumnWithPropertyName
+		 */
+		public static function getColumnNameFromProperty(
+			string $propertyName
+		): string {
+			/** @var MySQLModel $model */
+			$model = static::getModel();
+			return $model::getColumnName($propertyName);
+		}
+
+		/**
 		 * Fetches a ModelClass by the primary key
 		 */
 		public static function fetch(mixed $primaryKey): ModelClass|null{

--- a/src/ORM/MySQLModel.php
+++ b/src/ORM/MySQLModel.php
@@ -1,4 +1,29 @@
 <?php
+	namespace Nox\ORM;
+
+	use Nox\ORM\Exceptions\NoColumnWithPropertyName;
+
 	class MySQLModel{
 
+		/**
+		 * @param string $propertyName
+		 * @return string
+		 * @throws NoColumnWithPropertyName
+		 */
+		public static function getColumnName(string $propertyName): string{
+			/** @var \Nox\ORM\Interfaces\MySQLModelInterface $model */
+			$model = new static();
+
+			/** @var ColumnDefinition[] $columns */
+			$columns = $model->getColumns();
+
+			foreach($columns as $column){
+				if ($column->classPropertyName === $propertyName){
+					return $column->name;
+				}
+			}
+
+			$modelClass = $model::class;
+			throw new NoColumnWithPropertyName("No column with property name {$propertyName} in {$modelClass}.");
+		}
 	}


### PR DESCRIPTION
- Implement ModelClass::getColumnNameFromProperty(string $propertyName)
- Allow COALESCE and CONCAT to be in WHERE clauses