### PR TITLE
Last-Modified, ETag, and cache validation check implementation

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -20,6 +20,16 @@
 			self::$lastProcessedRequestPayload = $requestPayload;
 		}
 
+		public static function getFirstHeaderValue(string $headerName): ?string{
+			foreach(getallheaders() as $name => $value){
+				if (strtolower($name) === strtolower($headerName)){
+					return $value;
+				}
+			}
+
+			return null;
+		}
+
 		/**
 		 * Fetches the raw body of a request
 		 */


### PR DESCRIPTION
Static files now send a Last-Modified and Etag header. The Etag header value is just a timestamp of when that static file was last modified.

If no last-modified time (filemtime returns false) then neither of those headers will be added.

If the client/browser sends an If-None-Match header and the value is different than the file Etag, then a refreshed version of that file will be sent.