### PR TITLE
Implement byRaw for ResultOrder

### DIFF
--- a/src/ORM/ResultOrder.php
+++ b/src/ORM/ResultOrder.php
@@ -25,4 +25,12 @@
 			return $this;
 		}
 
+		/**
+		 * Adds a column order clause, but doesn't wrap the column in backticks. Returns itself for chaining.
+		 */
+		public function byRaw(string $columnName, string $order): self{
+			$this->orderClauses[] = sprintf("%s %s", $columnName, $order);
+			return $this;
+		}
+
 	}


### PR DESCRIPTION
Doesn't wrap the column in backticks, for use in custom column ordering aggregation.