### PR TITLE
Modify 304 Caching

### DIFF
--- a/example/nox-request.php
+++ b/example/nox-request.php
@@ -34,7 +34,7 @@
 	$nox->mapExtensionToMimeType("svg", "image/svg+xml");
 
 	// Mime caches
-	$nox->addCacheTimeForMime("image/png", 86400 * 60);
+	$nox->addCacheTimeForMime("image/png", 600);
 	$nox->addCacheTimeForMime("image/jpeg", 86400 * 60);
 	$nox->addCacheTimeForMime("text/css", 86400 * 60);
 	$nox->addCacheTimeForMime("text/plain", 86400 * 60);

--- a/example/src/HomeController.php
+++ b/example/src/HomeController.php
@@ -17,7 +17,7 @@
 		 * @throws ViewFileDoesNotExist
 		 * @throws LayoutDoesNotExist
 		 */
-		#[Route("PUT", "/")]
+		#[Route("GET", "/")]
 		public function homeView(Request $request): string{
 			return Renderer::renderView("home.html");
 		}

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -79,6 +79,7 @@
 							 * setting for that mime type.
 							 */
 							$cacheTime = $this->noxInstance->staticFileHandler->getCacheTimeForMime($mimeType);
+							header("content-type: $mimeType");
 							if ($cacheTime !== null) {
 
 								header(sprintf("cache-control: max-age=%d", $cacheTime));
@@ -105,7 +106,6 @@
 							}
 
 							$fileContents = file_get_contents(realpath($staticFilePath));
-							header("content-type: $mimeType");
 							header("content-length: " . strlen($fileContents));
 
 							// Only output for GET methods and not HEAD

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -96,11 +96,10 @@
 									// Check if the client sent an "If-None-Match" header with the same etag used above
 									// If so, simply respond with 304 Not Modified and exit.
 									// Else, don't exit
-									$ifNoneMatch = Request::getFirstHeaderValue("If-None-Match");
+									$ifNoneMatch = $this->currentRequest->getHeaderValue("If-None-Match");
 									if ((string) $lastModifiedTime === $ifNoneMatch){
-										// Etags match, no need to send file. It's not stale
+										// Etags match, set 304 status
 										http_response_code(304);
-										exit();
 									}
 								}
 							}

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -82,8 +82,8 @@
 							header("content-type: $mimeType");
 							if ($cacheTime !== null) {
 
-								header("Vary: If-None-Match, etag, last-modified, cache-control");
 								header(sprintf("cache-control: max-age=%d; must-revalidate", $cacheTime));
+								header("vary: *");
 
 								$lastModifiedTime = filemtime($staticFilePath);
 								if ($lastModifiedTime !== false){

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -82,8 +82,8 @@
 							header("content-type: $mimeType");
 							if ($cacheTime !== null) {
 
-								header(sprintf("cache-control: max-age=%d", $cacheTime));
 								header("Vary: If-None-Match, etag, last-modified, cache-control");
+								header(sprintf("cache-control: max-age=%d; must-revalidate", $cacheTime));
 
 								$lastModifiedTime = filemtime($staticFilePath);
 								if ($lastModifiedTime !== false){


### PR DESCRIPTION
RFC states that Content-Length can/should be returned in a HEAD request.

Additionally, change Vary and Cache-Control headers to be less specific and more specifics